### PR TITLE
fix: make backlog size an argument for .listen()

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Emitted when the server is listening.
 
 Unordered array containing the current active connections
 
-#### `server.listen(port, [address], [onlistening])`
+#### `server.listen(port, [address], [backlog], [onlistening])`
 
 Listen on a port.
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -33,9 +33,10 @@ class Server extends events.EventEmitter {
     binding.turbo_net_tcp_close(this._handle)
   }
 
-  listen (port, address, onlistening) {
+  listen (port, address, backlog, onlistening) {
     if (typeof port === 'function') return this.listen(0, null, port)
     if (typeof address === 'function') return this.listen(port, null, address)
+    if (typeof backlog === 'function') return this.listen(port, address, 511, backlog)
     if (!port) port = 0
     if (typeof port !== 'number') port = Number(port)
 
@@ -50,7 +51,7 @@ class Server extends events.EventEmitter {
       self._init()
 
       try {
-        binding.turbo_net_tcp_listen(self._handle, port, ip)
+        binding.turbo_net_tcp_listen(self._handle, port, ip, backlog)
       } catch (err) {
         self.emit('error', err)
       }

--- a/src/turbo_net.c
+++ b/src/turbo_net.c
@@ -170,10 +170,11 @@ NAPI_METHOD(turbo_net_tcp_destroy) {
 }
 
 NAPI_METHOD(turbo_net_tcp_listen) {
-  NAPI_ARGV(3)
+  NAPI_ARGV(4)
   NAPI_ARGV_BUFFER_CAST(turbo_net_tcp_t *, self, 0)
   NAPI_ARGV_UINT32(port, 1)
   NAPI_ARGV_UTF8(ip, 17, 2)
+  NAPI_ARGV_UINT32(backlog, 3)
 
   int err;
   struct sockaddr_in addr;
@@ -187,7 +188,7 @@ NAPI_METHOD(turbo_net_tcp_listen) {
   ))
 
   // TODO: research backlog
-  NAPI_UV_THROWS(err, uv_listen(TURBO_NET_STREAM, 511, on_uv_connection));
+  NAPI_UV_THROWS(err, uv_listen(TURBO_NET_STREAM, backlog, on_uv_connection));
 
   return NULL;
 }


### PR DESCRIPTION
- `server.listen(port, [address], [backlog], [onlistening])`, similar to `net`
fixes: #8 