### PR TITLE
Add support for node cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Connect to a TCP server. Options include:
 ``` js
 {
   allowHalfOpen: false // set to true to allow half open TCP connections
+  reusePort: true // Disable if you don't want SO_REUSEPORT to be set
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Create a new TCP server. Options include:
 
 ``` js
 {
-  allowHalfOpen: false // set to true to allow half open TCP connections
+  allowHalfOpen: false, // set to true to allow half open TCP connections
+  reusePort: true // Disable if you don't want SO_REUSEPORT to be set (SO_REUSEADDR on windows)
 }
 ```
 
@@ -88,7 +89,6 @@ Connect to a TCP server. Options include:
 ``` js
 {
   allowHalfOpen: false // set to true to allow half open TCP connections
-  reusePort: true // Disable if you don't want SO_REUSEPORT to be set
 }
 ```
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -34,7 +34,8 @@ class Connection extends events.EventEmitter {
       this._onwrite,
       this._onread,
       this._onfinish,
-      this._onclose
+      this._onclose,
+      0
     )
 
     if (server) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -2,6 +2,8 @@ const binding = require('./binding')
 const Connection = require('./connection')
 const lookup = require('./lookup')
 const events = require('events')
+const semver = require('semver')
+const os = require('os')
 
 class Server extends events.EventEmitter {
   constructor (opts) {
@@ -11,6 +13,11 @@ class Server extends events.EventEmitter {
     this.connections = []
     this.allowHalfOpen = !!opts.allowHalfOpen
     this.reusePort = (opts.reusePort || opts.reusePort == null) ? 1 : 0
+
+    // SO_REUSEPORT is only supported on kernel 3.9+
+    if (os.platform() === 'linux' && !semver.satisfies(semver.coerce(os.release()), '>=3.9')) {
+      this.reusePort = 0
+    }
 
     this._closed = false
     this._address = null

--- a/lib/server.js
+++ b/lib/server.js
@@ -10,6 +10,7 @@ class Server extends events.EventEmitter {
 
     this.connections = []
     this.allowHalfOpen = !!opts.allowHalfOpen
+    this.reusePort = (opts.reusePort || opts.reusePort == null) ? 1 : 0
 
     this._closed = false
     this._address = null
@@ -71,7 +72,8 @@ class Server extends events.EventEmitter {
       null,
       null,
       null,
-      this._onclose
+      this._onclose,
+      this.reusePort
     )
   }
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "napi-macros": "^1.3.0",
     "node-gyp-build": "^3.3.0",
+    "semver": "^5.5.1",
     "unordered-set": "^2.0.0"
   },
   "devDependencies": {

--- a/src/turbo_net.c
+++ b/src/turbo_net.c
@@ -197,7 +197,7 @@ NAPI_METHOD(turbo_net_tcp_listen) {
   NAPI_UV_THROWS(err, uv_tcp_bind(
     &(self->handle),
     (const struct sockaddr *) &addr,
-    4
+    0
   ))
 
   // TODO: research backlog

--- a/test/server.js
+++ b/test/server.js
@@ -68,12 +68,6 @@ tape('listen on used port', function (t) {
 })
 
 tape(`listen on used port (SO_REUSEPORT) (${os.platform()}:${os.release()})`, function (t) {
-  if (os.platform() === 'win32') {
-    t.pass('SO_REUSEPORT not supported on windows')
-    t.end()
-    return
-  }
-
   if (os.platform() === 'linux' && !semver.satisfies(semver.coerce(os.release()), '>=3.9')) {
     t.pass('SO_REUSEPORT only supported on kernel 3.9+')
     t.end()

--- a/test/server.js
+++ b/test/server.js
@@ -68,7 +68,7 @@ tape('listen on used port', function (t) {
 })
 
 tape(`listen on used port (SO_REUSEPORT) (${os.platform()}:${os.release()})`, function (t) {
-  if (os.platform() === 'windows') {
+  if (os.platform() === 'win32') {
     t.pass('SO_REUSEPORT not supported on windows')
     t.end()
     return

--- a/test/server.js
+++ b/test/server.js
@@ -1,5 +1,7 @@
 const tape = require('tape')
 const turbo = require('../')
+const os = require('os')
+const semver = require('semver')
 
 tape('listen', function (t) {
   const server = turbo.createServer()
@@ -66,6 +68,18 @@ tape('listen on used port', function (t) {
 })
 
 tape('listen on used port (SO_REUSEPORT)', function (t) {
+  if (os.platform() === 'windows') {
+    t.pass('SO_REUSEPORT not supported on windows')
+    t.end()
+    return
+  }
+
+  if (os.platform() === 'linux' && !semver.satisfies(semver.coerce(os.release()), '>=3.9')) {
+    t.pass('SO_REUSEPORT only supported on kernel 3.9+')
+    t.end()
+    return
+  }
+
   const server = turbo.createServer()
 
   server.listen(function () {

--- a/test/server.js
+++ b/test/server.js
@@ -46,10 +46,14 @@ tape('address no listen', function (t) {
 })
 
 tape('listen on used port', function (t) {
-  const server = turbo.createServer()
+  const server = turbo.createServer({
+    reusePort: false
+  })
 
   server.listen(function () {
-    const another = turbo.createServer()
+    const another = turbo.createServer({
+      reusePort: false
+    })
 
     another.on('error', function (err) {
       server.close()
@@ -58,5 +62,20 @@ tape('listen on used port', function (t) {
     })
 
     another.listen(server.address().port)
+  })
+})
+
+tape('listen on used port (SO_REUSEPORT)', function (t) {
+  const server = turbo.createServer()
+
+  server.listen(function () {
+    const another = turbo.createServer()
+
+    another.listen(server.address().port, function () {
+      server.close()
+      another.close()
+      t.pass('should not error')
+      t.end()
+    })
   })
 })

--- a/test/server.js
+++ b/test/server.js
@@ -67,7 +67,7 @@ tape('listen on used port', function (t) {
   })
 })
 
-tape('listen on used port (SO_REUSEPORT)', function (t) {
+tape(`listen on used port (SO_REUSEPORT) (${os.platform()}:${os.release()})`, function (t) {
   if (os.platform() === 'windows') {
     t.pass('SO_REUSEPORT not supported on windows')
     t.end()

--- a/test/write.js
+++ b/test/write.js
@@ -2,7 +2,7 @@ const tape = require('tape')
 const turbo = require('../')
 
 tape('writev', function (t) {
-  const server = turbo.createServer(echo)
+  const server = turbo.createServer(echo, {reusePort: false})
 
   server.listen(function () {
     const client = turbo.connect(server.address().port)
@@ -22,7 +22,7 @@ tape('writev', function (t) {
 })
 
 tape('writev after connect', function (t) {
-  const server = turbo.createServer(echo)
+  const server = turbo.createServer(echo, {reusePort: false})
 
   server.listen(function () {
     const client = turbo.connect(server.address().port)
@@ -44,7 +44,7 @@ tape('writev after connect', function (t) {
 })
 
 tape('writev before and after connect', function (t) {
-  const server = turbo.createServer(echo)
+  const server = turbo.createServer(echo, {reusePort: false})
 
   server.listen(function () {
     const client = turbo.connect(server.address().port)
@@ -73,7 +73,7 @@ tape('writev before and after connect', function (t) {
 })
 
 tape('writev twice', function (t) {
-  const server = turbo.createServer(echo)
+  const server = turbo.createServer(echo, {reusePort: false})
 
   server.listen(function () {
     const client = turbo.connect(server.address().port)
@@ -99,7 +99,7 @@ tape('writev twice', function (t) {
 })
 
 tape('write 256 buffers', function (t) {
-  const server = turbo.createServer(echo)
+  const server = turbo.createServer(echo, {reusePort: false})
 
   server.listen(function () {
     const client = turbo.connect(server.address().port)


### PR DESCRIPTION
Adds support for node cluster module using the SO_REUSEPORT option for the uv socket.  This can be disabled with the server option reusePort, which defaults to on. SO_REUSEADDR is used instead on windows.